### PR TITLE
specifying module entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "readmeFilename": "README.md",
   "license" : "MIT",
   "description": "obtain [width, height] from an element or window",
+  "main": "domwh.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/iambumblehead/domwh.git"


### PR DESCRIPTION
Added a `main` entry in your package.json. I believe this is necessary since your entry point has a non-standard name. Also, browserify seems to depend on this property to work correctly
